### PR TITLE
Fix command injection vulnerability

### DIFF
--- a/git.js
+++ b/git.js
@@ -1,7 +1,7 @@
 // imports
 var fs = require('fs');
 var path = require('path');
-var exec = require('child_process').exec;
+var execFile = require('child_process').execFile;
 
 // Class Git
 var Git = module.exports = function (options) {
@@ -27,13 +27,9 @@ Git.prototype.exec = function (command, options, args, callback) {
     options = [];
   }
 
-  args = args.join(' ');
   options = Git.optionsToString(options)
 
-  var cmd = this.binary + ' ' + this.args + ' ' + command + ' ' + options + ' '
-    + args;
-
-  exec(cmd, {
+  execFile(this.binary, [...this.args, command, ...options, ...args], {
     cwd: this.cwd
   }, function (err, stdout, stderr) {
     callback(err, stdout);
@@ -62,5 +58,5 @@ Git.optionsToString = function (options) {
     }
   }
 
-  return args.join(' ');
+  return args
 };

--- a/git.js
+++ b/git.js
@@ -1,6 +1,4 @@
 // imports
-var fs = require('fs');
-var path = require('path');
 var execFile = require('child_process').execFile;
 
 // Class Git


### PR DESCRIPTION
I've fixed the command injection vulnerability by using execFile rather than exec and passing in the arguments as an array. I've also removed unnecessary imports that aren't used anywhere in the code.